### PR TITLE
add flush_preview_env input to skip flushing preview envs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,8 @@ export const DEFAULT_VERSION_CONTENT_TYPE = "versionTracking";
 export const DEFAULT_VERSION_FIELD = "version";
 export const DEFAULT_DELETE_FEATURE = false;
 export const DEFAULT_SET_ALIAS = false;
+export const DEFAULT_FLUSH_PREVIEW_ENV = true;
+
 
 export const SPACE_ID = core.getInput('space_id', { required: true });
 export const MANAGEMENT_API_KEY = core.getInput('management_api_key', { required: true });
@@ -42,6 +44,7 @@ export const VERSION_FIELD = getInputOr('version_field', DEFAULT_VERSION_FIELD);
 export const DELETE_FEATURE = booleanOr(core.getInput('delete_feature'), DEFAULT_DELETE_FEATURE);
 export const SET_ALIAS = booleanOr(core.getInput('set_alias'), DEFAULT_SET_ALIAS);
 export const MIGRATIONS_DIR = path.join(GITHUB_WORKSPACE, getInputOr('migrations_dir', DEFAULT_MIGRATIONS_DIR));
+export const FLUSH_PREVIEW_ENV = booleanOr('flush_preview_env', DEFAULT_FLUSH_PREVIEW_ENV);
 
 export const CONTENTFUL_ALIAS = "master";
 export const DELAY = 32_000;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import {
   CONTENTFUL_ALIAS,
   DELAY,
   FEATURE_PATTERN,
+  FLUSH_PREVIEW_ENV,
   LOG_LEVEL,
   MASTER_PATTERN,
 } from './constants';
@@ -251,8 +252,14 @@ export const getEnvironment = async (
   );
 
   try {
-    const environment = await space.getEnvironment(environmentId);
-    await environment?.delete();
+    if (FLUSH_PREVIEW_ENV) {
+      const environment = await space.getEnvironment(environmentId);
+      await environment?.delete();
+    } else {
+      Logger.log(
+        `FLUSH_PREVIEW_ENV is set to ${FLUSH_PREVIEW_ENV}. Skipping flush.`
+      );
+    }
     Logger.success(`Environment deleted: "${environmentId}"`);
   } catch (e) {
     Logger.log(`Environment not found: "${environmentId}"`);


### PR DESCRIPTION
Adding an input variable that skips flushing preview environments if set to true. Due to the way we run our pipeline in expeditions repo, we don't want to recreate the preview environment if no migration files were changed/added. 